### PR TITLE
Updated license information and readme to be compatible with Dynatable license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,22 +1,16 @@
-Copyright (c) 2014 TODO: Write your name
+jQuery Dynatable is Copyright (C) 2011-2014  Steve Schwartz
+The jquery-dynatable-rails gem is Copyright (C) 2014 Ricardo do Valle
+Both libraries are licensed under the AGPL license below.
 
-MIT License
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This gem packages the jQuery [Dynatable](https://github.com/alfajango/jquery-dynatable)
 plugin for easy use with the Rails 3.1+ asset pipleine.
 
+Dynatable is licensed under AGPL, but has an optional [Commercial License
+which may be purchased](http://www.dynatable.com/license/),
+so make sure you have a valid license to use Dynatable.
+
 Dynatable is a funner, semantic, interactive table plugin using jQuery,
 HTML5, and JSON. And it's not just for tables.
 
@@ -34,6 +38,14 @@ Steve Schwartz -
 ![Alfa Jango logo](https://s3.amazonaws.com/s3.alfajango.com/github-readmes/AlfaJango_Logo_Black_noname-tiny.png)
 [Alfa Jango Open Source](http://os.alfajango.com) -
 [@alfajango on Twitter](https://twitter.com/alfajango)
+
+## License
+
+Dynatable is dual licensed, released under the Free Software Foundation's GNU Affero General Public License (AGPL),
+or see [license information](http://www.dynatable.com/license) for proprietary or commercial applications.
+
+**Note: The MIT license for early jquery-dynatable-rails versions <= 0.3.1 are
+incompatible with the Dynatable license.**
 
 ## Contributing
 


### PR DESCRIPTION
Hi there. Firstly, I just want to thank you for your support of dynatable, it's greatly appreciated! I just wanted to let you know that since this library packages the dynatable code, the [MIT license chosen](https://github.com/ricardodovalle/jquery-dynatable-rails/blob/6abd90d030417bb7ac8962d522e2d3c100eecda8/LICENSE.txt) is incompatible with the [AGPL license](https://github.com/alfajango/jquery-dynatable/blob/ce207ab5070bf6bf5482d9b4178b2b1b7cc88c98/LICENSE.txt) used by dynatable. If you could update the library to also use the AGPL or other compatible license, that would be great!

Also, as someone how has gone through the due diligence process surrounding a Rails application, one of the most tedious jobs is verifying that the open source code you've used in your project is licensed properly to allow transfer of ownership and use within the project. Generally the first thing I do is look through the Gemfile and check the licenses of all the gems, which often package other open source code, such as this one. It makes it a much more tedious job when I can't assume that the authors of those libraries have compatibly licensed their code with those of the code they've packaged. Since changing licenses in a project generally still means that any old versions retain their respective licenses, you may consider putting a note in the Readme that lets people know that the old MIT license was incompatible and could not be considered accurate.

Going forward, you may also consider including a note like the one in the [hicharts-rails gem Readme](https://github.com/PerfectlyNormal/highcharts-rails/blob/451e30e31390fabda6d14686bb284b094caf5bfd/README.markdown) letting people know that if the AGPL license is not sufficient for their needs, they may obtain their own license with Dynatable directly.

Sorry for the wall of text. I made a pull request with the requested changes to make it easier. Thanks again for your support!
